### PR TITLE
fixed bug causing nil output of plus_two method

### DIFF
--- a/lib/pry_debugging.rb
+++ b/lib/pry_debugging.rb
@@ -1,4 +1,4 @@
 def plus_two(num)
-	num + 2
-	num
+	#returns original number + 2
+	return num + 2
 end


### PR DESCRIPTION
It wasn't returning anything, silly lab. Now it is, plus 2!